### PR TITLE
Remove the "Most Used Languages" widget from `README.md` because it does not accurately reflect the languages I use

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,4 @@ Mississauga, ON, Canada | Dean's List 2024 & 2025
 ![NPM](https://img.shields.io/badge/NPM-%23CB3837.svg?style=for-the-badge&logo=npm&logoColor=white)
 
 ## GitHub Stats:
-<div align="center">
-
 ![](https://github-readme-stats.vercel.app/api?username=AvianSilk&theme=holi&hide_border=false&include_all_commits=true&count_private=true)
-<br/>
-![](https://github-readme-stats.vercel.app/api/top-langs/?username=AvianSilk&theme=holi&layout=donut)
-
-
-</div>


### PR DESCRIPTION
## Remove the "Most Used Languages" widget from `README.md` because it does not accurately reflect the languages I use.

* Two languages I use frequently, **Java** and **Python**, are not recognized by the widget since much of my work in those languages exists in repositories owned by others, such as school or university projects.
* As a result, the absence of Java and Python contradicts my claim that I am comfortable with these languages and may create confusion for readers.
* For this reason, the widget should be removed.
